### PR TITLE
Persist order via Supabase

### DIFF
--- a/src/components/fragebogen/CheckoutStep.tsx
+++ b/src/components/fragebogen/CheckoutStep.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/AuthContext";
 import CheckoutOrderSummary from "./CheckoutOrderSummary";
 import { Separator } from "@/components/ui/separator";
 
@@ -49,6 +51,7 @@ const CheckoutStep = ({
   onComplete, 
   onBack 
 }: CheckoutStepProps) => {
+  const { user } = useAuth();
   const [paymentMethod, setPaymentMethod] = useState<'creditCard' | 'paypal' | 'sepa'>('creditCard');
   const [isProcessing, setIsProcessing] = useState(false);
   
@@ -72,7 +75,7 @@ const CheckoutStep = ({
     }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
     const requiredFields = ['firstName', 'lastName', 'email', 'phone', 'street', 'houseNumber', 'postalCode', 'city'];
@@ -118,11 +121,41 @@ const CheckoutStep = ({
     }
     
     setIsProcessing(true);
-    
-    setTimeout(() => {
-      setIsProcessing(false);
-      onComplete();
-    }, 2000);
+
+    const { error } = await supabase.from('orders').insert({
+      patient_id: user.id,
+      total_amount: totalAmount,
+      shipping_address: {
+        firstName: contactInfo.firstName,
+        lastName: contactInfo.lastName,
+        email: contactInfo.email,
+        phone: contactInfo.phone,
+        street: contactInfo.street,
+        houseNumber: contactInfo.houseNumber,
+        postalCode: contactInfo.postalCode,
+        city: contactInfo.city,
+        country: contactInfo.country,
+      },
+      status: 'pending'
+    });
+
+    setIsProcessing(false);
+
+    if (error) {
+      toast({
+        title: 'Fehler',
+        description: 'Bestellung konnte nicht aufgegeben werden.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    toast({
+      title: 'Bestellung erfolgreich',
+      description: 'Ihre Bestellung wurde erfolgreich aufgegeben.'
+    });
+
+    onComplete();
   };
 
   return (


### PR DESCRIPTION
## Summary
- store order data with Supabase when completing checkout
- show toast notifications for success/failure

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e59d8b3fc8332a7cd08a8418b770f