### PR TITLE
Use env password for functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Copy the example environment file and add your Supabase credentials.
 cp .env.example .env
 
+# Optionally specify `DEFAULT_USER_PASSWORD` in the `.env` file.
+# This password will be applied to automatically created test users.
+
 # Step 4: Install the necessary dependencies.
 npm i
 

--- a/env.example
+++ b/env.example
@@ -1,2 +1,4 @@
 SUPABASE_URL=
 SUPABASE_PUBLISHABLE_KEY=
+# Password used for automatically created test accounts
+DEFAULT_USER_PASSWORD=

--- a/supabase/functions/create-test-data/index.ts
+++ b/supabase/functions/create-test-data/index.ts
@@ -2,6 +2,9 @@
 import { serve } from "https://deno.land/std@0.188.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.23.0";
 
+const DEFAULT_PASSWORD =
+  Deno.env.get("DEFAULT_USER_PASSWORD") ?? crypto.randomUUID();
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
@@ -27,21 +30,21 @@ serve(async (req) => {
     const testUsers = [
       {
         email: "patient@example.com",
-        password: "password",
+        password: DEFAULT_PASSWORD,
         role: "patient",
         first_name: "Test",
         last_name: "Patient"
       },
       {
         email: "doctor@example.com",
-        password: "password",
+        password: DEFAULT_PASSWORD,
         role: "doctor",
         first_name: "Test",
         last_name: "Doctor"
       },
       {
         email: "admin@example.com",
-        password: "password",
+        password: DEFAULT_PASSWORD,
         role: "admin",
         first_name: "Test",
         last_name: "Admin"

--- a/supabase/functions/create-test-users/index.ts
+++ b/supabase/functions/create-test-users/index.ts
@@ -2,6 +2,9 @@
 import { serve } from "https://deno.land/std@0.188.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.23.0";
 
+const DEFAULT_PASSWORD =
+  Deno.env.get("DEFAULT_USER_PASSWORD") ?? crypto.randomUUID();
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
@@ -23,21 +26,21 @@ serve(async (req) => {
     const testUsers = [
       {
         email: "patient@example.com",
-        password: "password",
+        password: DEFAULT_PASSWORD,
         role: "patient",
         first_name: "Test",
         last_name: "Patient"
       },
       {
         email: "doctor@example.com",
-        password: "password",
+        password: DEFAULT_PASSWORD,
         role: "doctor",
         first_name: "Test",
         last_name: "Doctor"
       },
       {
         email: "admin@example.com",
-        password: "password",
+        password: DEFAULT_PASSWORD,
         role: "admin",
         first_name: "Test",
         last_name: "Admin"

--- a/supabase/functions/verify-login-code/index.ts
+++ b/supabase/functions/verify-login-code/index.ts
@@ -2,6 +2,9 @@
 import { serve } from "https://deno.land/std@0.188.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.23.0";
 
+const DEFAULT_PASSWORD =
+  Deno.env.get("DEFAULT_USER_PASSWORD") ?? crypto.randomUUID();
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
@@ -102,7 +105,7 @@ serve(async (req) => {
       if (userRole === 'doctor' || userRole === 'admin') {
         createOptions = {
           ...createOptions,
-          password: 'password' // Use a simple password for test accounts
+          password: DEFAULT_PASSWORD
         };
       }
       
@@ -144,7 +147,7 @@ serve(async (req) => {
       if (userRole === 'doctor' || userRole === 'admin') {
         try {
           const { error: passwordError } = await supabase.auth.admin.updateUserById(userId, {
-            password: 'password' // Reset to a simple password for test accounts
+            password: DEFAULT_PASSWORD
           });
           
           if (passwordError) {


### PR DESCRIPTION
## Summary
- use `DEFAULT_USER_PASSWORD` env value (or a random value) for generated accounts
- document how to set the default password

## Testing
- `npm run lint` *(fails: Unexpected any in several files)*

------
https://chatgpt.com/codex/tasks/task_e_685e665efc8c83328f0dc8a06602d8d1